### PR TITLE
fix: handle network-down gracefully in auth initialization

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -4,11 +4,16 @@
 import React, { useEffect, useRef, useState } from 'react';
 import AuthContext from './AuthContext.js';
 import { supabase } from '@/shared/utils/supabaseClient.ts';
+import { getUserProfile } from '@/shared/utils/helper.ts';
 import { toast } from 'sonner';
 import type { AppUser } from '@/shared/types/AppUser.ts';
 import type { Session } from '@supabase/supabase-js';
 import useStudyPlan from '@/features/dashboard/hooks/useStudyPlan.js';
 import { appStorage } from '@/storage/storageService.ts';
+
+// Maximum time (ms) to wait for the initial Supabase session before falling
+// back to the locally cached profile. Adjust here if needed — do not inline.
+const SESSION_TIMEOUT_MS = 8_000;
 
 // The AuthProvider component handles all authentication logic.
 // It exposes the user object, login/logout functions, and loading state to its children.
@@ -89,22 +94,59 @@ const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => 
 
             setLoading(false);
         };
-
-        // This function attempts to get the initial session, retrying a few times.
-        // This can help with race conditions where the app initializes before the Supabase client.
+        // Attempts to get the initial session with a bounded timeout that covers
+        // the entire flow: getSession() AND the Supabase upsert inside handleSession.
+        // Both are network calls; either one can hang indefinitely when offline.
+        //
+        // A closure-level `cancelled` flag is checked after each awaited step so
+        // the retry loop exits immediately once the timeout fires — no extra
+        // getSession() calls are made in the background.
+        //
+        // On timeout: the cached AppUser profile is restored from localStorage so
+        // the routing layer reaches /dashboard instead of the landing page.
+        // userIdRef is intentionally left unset so that the existing
+        // onAuthStateChange listener re-runs handleSession in full (upsert + fresh
+        // setUser) once connectivity is restored automatically.
         const initSession = async () => {
+            let cancelled = false;
+
+            const timeoutId = setTimeout(() => {
+                cancelled = true;
+                const cachedProfile = getUserProfile();
+                if (
+                    cachedProfile &&
+                    'id' in cachedProfile &&
+                    cachedProfile.id &&
+                    cachedProfile.id !== '1'
+                ) {
+                    setUser(cachedProfile);
+                }
+                setLoading(false);
+            }, SESSION_TIMEOUT_MS);
+
             for (let i = 0; i < 5; i++) {
+                if (cancelled) break;
+
                 const {
                     data: { session },
                 } = await supabase.auth.getSession();
+
+                // Timeout may have fired while getSession() was pending;
+                // bail out before any further state writes.
+                if (cancelled) break;
+
                 if (session) {
                     await handleSession(session);
-                    return; // Exit once the session is handled.
+                    break; // handleSession calls setLoading(false) internally.
                 }
+
                 await new Promise((r) => setTimeout(r, 500)); // Wait before retrying.
             }
-            // If no session is found after retries, stop the loading state.
-            setLoading(false);
+
+            // Cancel the pending timer (no-op if it already fired) and unblock
+            // the loading state for the no-session / first-time-user path.
+            clearTimeout(timeoutId);
+            if (!cancelled) setLoading(false);
         };
 
         initSession();


### PR DESCRIPTION
Fixes #4

Problem
-------
When the app starts offline (or on a very slow connection), the auth initialization hangs indefinitely. There are two network calls in the startup path, either of which can block forever:

1. supabase.auth.getSession() — triggers a token refresh when the cached JWT is expired, which makes a fetch to the auth server.
2. supabase.from('users').upsert() inside handleSession — called immediately after a session is found; also a network call.

Because loading starts as true and is only set to false inside handleSession, either call hanging keeps the spinner visible with no timeout and no fallback.

Additionally, after all 5 retries exhausted without a session, the app fell through to the landing page even though gate_user_profile was already stored in localStorage from the user's last successful login.

Fix
---
Modified src/app/providers/AuthProvider.tsx only.

A single setTimeout (SESSION_TIMEOUT_MS = 8_000, named constant) covers the entire initSession flow. A closure-level boolean flag cancelled is checked after each awaited step:

  - After getSession() returns: if the timer already fired, the loop breaks immediately — no more getSession() calls, no handleSession call.
  - The timer also fires if getSession() succeeds but the upsert inside handleSession hangs: cancelled is set, the cached profile is restored, and loading stops.
  - On the happy path (fast network), clearTimeout() prevents the timer from ever firing. Behaviour is identical to before this change.

On timeout, getUserProfile() reads the existing gate_user_profile from localStorage and calls setUser() with the cached AppUser — no type casting, uses the existing AppUser abstraction and helper. userIdRef is intentionally left unset so the existing onAuthStateChange listener re-runs handleSession in full (fresh upsert + setUser) automatically once connectivity is restored, requiring no manual refresh.

Files changed
-------------
  src/app/providers/AuthProvider.tsx  — only file modified

Scenarios
---------
Online, fast:          timer never fires; flow identical to before.
Online, slow (<8 s):   timer fires; cache shown; onAuthStateChange
                       recovers when upsert eventually completes.
Offline, cached user:  timer fires after 8 s; dashboard loads from cache.
Offline, no cache:     timer fires; loading stops; landing page shown
                       (correct — no session, no profile to restore).
Network recovery:      onAuthStateChange fires automatically; fresh
                       handleSession runs; data synced.

**What does this PR do?**

Fixes the indefinite loading spinner when the app starts offline.
Adds an 8-second timeout to auth initialization that falls back to
the cached localStorage profile (gate_user_profile) if Supabase
is unreachable. On network recovery, onAuthStateChange automatically
re-syncs the session — no manual refresh needed.

**How should this be manually tested?**

1. Open the app and log in normally
2. Disconnect internet (or disable Wi-Fi)
3. Refresh the page
4. Expected: loading spinner shows for ~8 seconds, then dashboard
   loads from cached profile
5. Reconnect internet
6. Expected: session syncs automatically via onAuthStateChange


**What are the relevant tickets?**

Fixes #4


**Screenshots (if appropriate)**
